### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,6 +13,9 @@ on:
     - main
     - develop
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Fireball19/idle-game-generator-visualization-tool/security/code-scanning/1](https://github.com/Fireball19/idle-game-generator-visualization-tool/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/gradle.yml` at the workflow root (recommended here since there is one job and no job-specific differences shown).  
Use least privilege for current behavior: `contents: read`.

This preserves existing functionality (checkout + build) while preventing implicit broad token scopes from repo/org defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
